### PR TITLE
Add Telecom Provider "churn" dataset

### DIFF
--- a/machine-learning/telecom-churn/README.md
+++ b/machine-learning/telecom-churn/README.md
@@ -1,0 +1,43 @@
+# Telecom Provider "churn" dataset
+
+The dataset used to demonstrate the use of Pycaret and CrateDB for training 
+machine learning models is a churn dataset of a telecom provider.
+
+It includes various attributes relating to customer demographics, services 
+subscribed to, billing information, and churn status.
+
+- `customerID`: A unique identifier for each customer.
+- `gender`: The customer's gender (e.g., Male, Female).
+- `SeniorCitizen`: Indicates whether the customer is a senior citizen (1) or 
+  not (0).
+- `Partner`: Indicates whether the customer has a partner (Yes) or not (No).
+- `Dependents`: Indicates whether the customer has dependents (Yes) or not 
+  (No).
+- `tenure`: The total amount of time that the customer has been with the 
+  company.
+- `PhoneService`: Indicates whether the customer has a phone service (Yes) 
+  or not (No).
+- `MultipleLines`: Indicates whether the customer has multiple lines (Yes), 
+  no multiple lines (No), or no phone service.
+- `InternetService`: The type of internet service the customer has (DSL, 
+  Fiber optic, or None).
+- `OnlineSecurity`: Indicates whether the customer subscribes to an additional
+   online security service (Yes, No, or No internet service).
+- `DeviceProtection`: Whether the customer has a device protection plan (Yes, 
+  No, or No internet service).
+- `TechSupport`: Indicates whether the customer has tech support services (Yes, 
+  No, or No internet service).
+- `StreamingTV`: Indicates if the customer has streaming TV service (Yes, No, 
+  or No internet service).
+- `StreamingMovies`: Indicates if the customer has streaming movies service 
+  (Yes, No, or No internet service).
+- `Contract`: The type of contract the customer has (Month-to-month, One year, 
+  Two years).
+- `PaperlessBilling`: Indicates whether the customer has paperless billing (Yes) 
+  or not (No).
+- `PaymentMethod`: The customer's payment method (Electronic check, 
+  Mailed check, Credit card (automatic), etc.).
+- `MonthlyCharges`: The amount charged to the customer each month.
+- `TotalCharges`: The total amount charged to the customer over the time they 
+  have been with the company.
+- `Churn`: Indicates whether the customer has churned (Yes) or not (No).

--- a/machine-learning/telecom-churn/churn-dataset.csv
+++ b/machine-learning/telecom-churn/churn-dataset.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:88be4b93fbe0cc83421af1c503794c97c342eca914c1576db7c276e61d61358a
+size 977501


### PR DESCRIPTION
## About

Add the `churn-dataset.csv` file from https://github.com/crate/cratedb-examples/pull/122 to a canonical place it can be referred to / pulled from different spots, without needing to re-add it to different directories or repositories.

## Synopsis

The canonical URL to the dataset is, after merging:

~~https://github.com/crate/cratedb-datasets/raw/main/machine-learning/telecom-churn/churn-dataset.csv~~

Edit: https://github.com/crate/cratedb-datasets/raw/main/machine-learning/automl/churn-dataset.csv


## Details

The file has been added to the repository using [Git LFS](https://git-lfs.com/).

```
$ git push
Uploading LFS objects: 100% (1/1), 978 KB | 133 KB/s, done.
```

/cc @andnig, @ckurze, @seut, @matriv, @marijaselakovic, @karynzv 