### PR TITLE
Chore: Improve README, update `.gitattributes`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,5 +2,7 @@
 *.csv filter=lfs diff=lfs merge=lfs -text
 *.gz filter=lfs diff=lfs merge=lfs -text
 *.json filter=lfs diff=lfs merge=lfs -text
+*.jsonl filter=lfs diff=lfs merge=lfs -text
+*.ndjson filter=lfs diff=lfs merge=lfs -text
 *.parquet filter=lfs diff=lfs merge=lfs -text
 *.pdf filter=lfs diff=lfs merge=lfs -text

--- a/README.md
+++ b/README.md
@@ -18,6 +18,21 @@ query when experimenting with CrateDB.
 https://s3.amazonaws.com/crate.sampledata/
 
 
+
+## Contributions
+
+Before adding files to this repository, please make sure to install [Git LFS]
+beforehand. On macOS, it works like this:
+```shell
+brew install git-lfs
+git lfs install
+```
+
+Also, please check the `.gitattributes` file, which lists all the file types assigned
+to be handled by Git LFS. If you are adding a file of another type, make sure it is
+listed there.
+
+
 ## Included files
 
 ### timeseries/anomaly/nab-machine-failure.csv
@@ -42,5 +57,7 @@ failure of the machine.
   2013-12-02 21:25:00,76.12416182
   ```
 
+
+[Git LFS]: https://git-lfs.com/
 [NAB Data Corpus]: https://github.com/numenta/NAB/tree/master/data
 [nab-machine-failure.csv]: https://github.com/crate/cratedb-datasets/blob/main/timeseries/anomaly/nab-machine-failure.csv


### PR DESCRIPTION
Thank you for using Git LFS at GH-5. This patch improves the documentation correspondingly.

- README: Add section about contributions, specifically about Git LFS.
- Update `.gitattributes`, adding `.jsonl` and `.ndjson` file types.
