### PR TITLE
cloud-tutorials: Add data loading SQL statements (DDL and DML)

### DIFF
--- a/cloud-tutorials/README.md
+++ b/cloud-tutorials/README.md
@@ -150,3 +150,48 @@ CREATE TABLE devices_info (
 - **manufacturer**: Name of the manufacturer of the device.
 - **model**: Model name of the device.
 - **os_name**: Name of the operating system running on the device.
+
+
+## SQL Files
+The `.sql` files can be used for loading the data files using SQL.
+
+The statements can not be used 1:1. Before running them on the database,
+they needed to be splitted, and the `{table}` template variables needs
+to be interpolated.
+
+In order to interpolate a table name, use one of the statements
+outlined below.
+
+### Linux and \*nix
+```
+cat load_devices_info.sql | sed -e 's!{table}!devices_info!'
+```
+```
+cat load_devices_readings.sql | sed -e 's!{table}!devices_readings!'
+```
+```
+cat load_marketing.sql | sed -e 's!{table}!marketing_data!'
+```
+```
+cat load_netflix.sql | sed -e 's!{table}!netflix_catalog!'
+```
+```
+cat load_weather.sql | sed -e 's!{table}!weather_data!'
+```
+
+### Windows
+```
+(Get-Content -path load_devices_info.sql -Raw) -replace '{table}','devices_info'
+```
+```
+(Get-Content -path load_devices_readings.sql -Raw) -replace '{table}','devices_readings'
+```
+```
+(Get-Content -path load_marketing.sql -Raw) -replace '{table}','marketing_data'
+```
+```
+(Get-Content -path load_netflix.sql -Raw) -replace '{table}','netflix_catalog'
+```
+```
+(Get-Content -path load_weather.sql -Raw) -replace '{table}','weather_data'
+```

--- a/cloud-tutorials/load_devices_info.sql
+++ b/cloud-tutorials/load_devices_info.sql
@@ -1,0 +1,17 @@
+-- CrateDB Example Datasets
+-- https://github.com/crate/cratedb-datasets
+
+CREATE TABLE IF NOT EXISTS {table} (
+   "device_id" TEXT,
+   "api_version" TEXT,
+   "manufacturer" TEXT,
+   "model" TEXT,
+   "os_name" TEXT
+);
+
+COPY {table}
+FROM 'https://github.com/crate/cratedb-datasets/raw/main/cloud-tutorials/devices_info.json.gz'
+WITH (compression='gzip', empty_string_as_null=true)
+RETURN SUMMARY;
+
+REFRESH TABLE {table}

--- a/cloud-tutorials/load_devices_readings.sql
+++ b/cloud-tutorials/load_devices_readings.sql
@@ -1,0 +1,28 @@
+-- CrateDB Example Datasets
+-- https://github.com/crate/cratedb-datasets
+
+CREATE TABLE IF NOT EXISTS {table} (
+   "ts" TIMESTAMP WITH TIME ZONE,
+   "device_id" TEXT,
+   "battery" OBJECT(DYNAMIC) AS (
+      "level" BIGINT,
+      "status" TEXT,
+      "temperature" DOUBLE PRECISION
+   ),
+   "cpu" OBJECT(DYNAMIC) AS (
+      "avg_1min" DOUBLE PRECISION,
+      "avg_5min" DOUBLE PRECISION,
+      "avg_15min" DOUBLE PRECISION
+   ),
+   "memory" OBJECT(DYNAMIC) AS (
+      "free" BIGINT,
+      "used" BIGINT
+   )
+);
+
+COPY {table}
+FROM 'https://github.com/crate/cratedb-datasets/raw/main/cloud-tutorials/devices_readings.json.gz'
+WITH (compression='gzip', empty_string_as_null=true)
+RETURN SUMMARY;
+
+REFRESH TABLE {table}

--- a/cloud-tutorials/load_marketing.sql
+++ b/cloud-tutorials/load_marketing.sql
@@ -1,0 +1,20 @@
+-- CrateDB Example Datasets
+-- https://github.com/crate/cratedb-datasets
+
+CREATE TABLE {table} (
+    campaign_id TEXT PRIMARY KEY,
+    source TEXT,
+    metrics OBJECT(DYNAMIC) AS (
+        clicks INTEGER,
+        impressions INTEGER,
+        conversion_rate DOUBLE PRECISION
+    ),
+    landing_page_url TEXT,
+    url_parts GENERATED ALWAYS AS parse_url(landing_page_url)
+);
+
+COPY {table}
+FROM 'https://github.com/crate/cratedb-datasets/raw/main/cloud-tutorials/data_marketing.json.gz'
+WITH (format = 'json', compression='gzip');
+
+REFRESH TABLE {table};

--- a/cloud-tutorials/load_netflix.sql
+++ b/cloud-tutorials/load_netflix.sql
@@ -1,0 +1,23 @@
+-- CrateDB Example Datasets
+-- https://github.com/crate/cratedb-datasets
+
+CREATE TABLE {table} (
+   "show_id" TEXT PRIMARY KEY,
+   "type" TEXT,
+   "title" TEXT,
+   "director" TEXT,
+   "cast" ARRAY(TEXT),
+   "country" TEXT,
+   "date_added" TIMESTAMP,
+   "release_year" TEXT,
+   "rating" TEXT,
+   "duration" TEXT,
+   "listed_in"  ARRAY(TEXT),
+   "description" TEXT INDEX using fulltext
+);
+
+COPY {table}
+FROM 'https://github.com/crate/cratedb-datasets/raw/main/cloud-tutorials/data_netflix.json.gz'
+WITH (format = 'json', compression='gzip');
+
+REFRESH TABLE {table};

--- a/cloud-tutorials/load_weather.sql
+++ b/cloud-tutorials/load_weather.sql
@@ -1,0 +1,16 @@
+-- CrateDB Example Datasets
+-- https://github.com/crate/cratedb-datasets
+
+CREATE TABLE {table} (
+    "timestamp" TIMESTAMP,
+    "location" VARCHAR,
+    "temperature" DOUBLE,
+    "humidity" DOUBLE,
+    "wind_speed" DOUBLE
+);
+
+COPY {table}
+FROM 'https://github.com/crate/cratedb-datasets/raw/main/cloud-tutorials/data_weather.csv.gz'
+WITH (format='csv', compression='gzip', empty_string_as_null=true);
+
+REFRESH TABLE {table};


### PR DESCRIPTION
## About
For developer and user convenience, let's add the DDL and DML statements from [Cloud Tutorials] to the repository, that's why we have it.

[Cloud Tutorials]: https://cratedb.com/docs/cloud/en/latest/tutorials/

## Remarks
I'd prefer a flat one-folder-per-dataset structure for future additions, in order to have some symmetry, and in order to be able to accompany each dataset with corresponding metadata files (README.md, LICENSE, init.sql, etc.), without needing to get into naming hell too quickly. Thanks!

When possible, and it doesn't break downstream consumers, we may conclude such a renaming of the existing resources by using symlinks.

## References
- https://github.com/crate-workbench/cratedb-toolkit/issues/89
- https://github.com/crate-workbench/cratedb-toolkit/pull/123