### PR TITLE
Publish content to web server, GitHub is not a CDN

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,3 +1,6 @@
+# GHA workflow recipe to upload repository content using WebDAV when changed.
+# In this setup, the workflow will connect to a tailnet first.
+# https://github.com/tailscale/github-action
 ---
 name: Publish content
 
@@ -23,6 +26,16 @@ jobs:
     name: Upload content to web server
     steps:
 
+    - name: Connect using Tailscale
+      uses: tailscale/github-action@v3
+      with:
+        oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+        oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+        tags: tag:ci
+
+    - name: Probe network connectivity
+      run: ping -c2 cdn-tailnet.vdc.cr8.net &
+
     - name: Acquire sources
       uses: actions/checkout@v4
 
@@ -36,7 +49,7 @@ jobs:
 
         [datasets-webdav]
         type = webdav
-        url = https://cdn.crate.io/downloads/datasets
+        url = http://cdn-tailnet.vdc.cr8.net/downloads/datasets
         vendor = other
 
         EOF

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,9 +5,11 @@
 name: Publish content
 
 on:
-  pull_request: ~
   push:
     branches: [ main ]
+
+  # Only able for testing purposes.
+  # pull_request: ~
 
   # Allow job to be triggered manually.
   workflow_dispatch:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,50 @@
+---
+name: Publish content
+
+on:
+  pull_request: ~
+  push:
+    branches: [ main ]
+
+  # Allow job to be triggered manually.
+  workflow_dispatch:
+
+# Cancel in-progress jobs when pushing to the same branch.
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+
+  publish-webserver:
+
+    runs-on: "ubuntu-latest"
+
+    name: Upload content to web server
+    steps:
+
+    - name: Acquire sources
+      uses: actions/checkout@v4
+
+    - name: Install Rclone
+      run: sudo apt-get install --yes --no-install-recommends --no-install-suggests rclone
+
+    - name: Configure Rclone
+      run: |
+        mkdir -p ~/.config/rclone
+        cat << EOF > ~/.config/rclone/rclone.conf
+
+        [datasets-webdav]
+        type = webdav
+        url = https://cdn.crate.io/downloads/datasets
+        vendor = other
+
+        EOF
+
+    - name: Upload content using WebDAV
+      env:
+        RCLONE_WEBDAV_USER: webdav
+        RCLONE_WEBDAV_PASS: ${{ secrets.RCLONE_WEBDAV_PASS }}
+      run: |
+        rclone sync $(pwd) datasets-webdav:/cratedb-datasets \
+          --copy-links --delete-excluded --exclude="/.git**"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,18 @@ jobs:
     name: Upload content to web server
     steps:
 
-    - name: Connect using Tailscale
+    - name: Acquire sources
+      uses: actions/checkout@v4
+
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v4
+
+    - name: Generate README
+      run: |
+        cat README.md | uv run --with markdown -m markdown > README.html
+        rm README.md
+
+    - name: Connect to tailnet
       uses: tailscale/github-action@v3
       with:
         oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
@@ -37,9 +48,6 @@ jobs:
 
     - name: Probe network connectivity
       run: ping -c2 cdn-tailnet.vdc.cr8.net &
-
-    - name: Acquire sources
-      uses: actions/checkout@v4
 
     - name: Install Rclone
       run: sudo apt-get install --yes --no-install-recommends --no-install-suggests rclone
@@ -56,7 +64,7 @@ jobs:
 
         EOF
 
-    - name: Upload content using WebDAV
+    - name: Publish using WebDAV
       env:
         RCLONE_WEBDAV_USER: webdav
         RCLONE_WEBDAV_PASS: ${{ secrets.RCLONE_WEBDAV_PASS }}

--- a/README.md
+++ b/README.md
@@ -13,6 +13,31 @@ The datasets are used for learning and experimenting,
 and to support blog posts and tech talks about CrateDB.
 
 
+## Usage
+
+How to acquire and use datasets provided by this repository.
+
+### Acquisition
+
+The content of this repository is published to an HTTP folder
+on the web server. Please consume all resources from there,
+because it is discouraged to use GitHub as a CDN.
+
+https://cdn.crate.io/downloads/datasets/cratedb-datasets/
+
+### Python API
+
+You can acquire datasets fluently in Python code by using
+CrateDB Toolkit's [Dataset API].
+```python
+from cratedb_toolkit.datasets import load_dataset
+load_dataset("tutorial/weather-basic")
+```
+Some of the datasets already include a default SQL DDL schema definition file,
+so provisioning them as a CrateDB database table is easier than needing to
+discover and type the correct `CREATE TABLE ...` statement manually.
+
+
 ## What's inside
 
 ### Embedded datasets
@@ -55,4 +80,5 @@ type, make sure it is listed there.
 
 
 
+[Dataset API]: https://cratedb-toolkit.readthedocs.io/datasets.html
 [Git LFS]: https://git-lfs.com/

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The content of this repository is published to an HTTP folder
 on the web server. Please consume all resources from there,
 because it is discouraged to use GitHub as a CDN.
 
-https://cdn.crate.io/downloads/datasets/cratedb-datasets/
+[https://cdn.crate.io/downloads/datasets/cratedb-datasets/]
 
 ### Python API
 
@@ -82,3 +82,4 @@ type, make sure it is listed there.
 
 [Dataset API]: https://cratedb-toolkit.readthedocs.io/datasets.html
 [Git LFS]: https://git-lfs.com/
+[https://cdn.crate.io/downloads/datasets/cratedb-datasets/]: https://cdn.crate.io/downloads/datasets/cratedb-datasets/


### PR DESCRIPTION
## About
Upload content of repository to web server when changed, in order to not fall into cost or other lock-in traps when using S3. We need to detour from using GitHub as a CDN, because it is not viable.

- https://github.com/crate/cratedb-datasets/issues/19#issuecomment-2577499087

## References
> Using raw download URLs in web pages or otherwise using those direct links as a form of CDN is discouraged.
> -- https://stackoverflow.com/a/58227912
