### PR TITLE
Update load_marketing.sql to pull example data from new URL.

### DIFF
--- a/cloud-tutorials/load_marketing.sql
+++ b/cloud-tutorials/load_marketing.sql
@@ -14,7 +14,7 @@ CREATE TABLE IF NOT EXISTS {table} (
 );
 
 COPY {table}
-FROM 'https://github.com/crate/cratedb-datasets/raw/main/cloud-tutorials/data_marketing.json.gz'
+FROM 'https://cdn.crate.io/downloads/datasets/cratedb-datasets/cloud-tutorials/data_marketing.json.gz'
 WITH (format = 'json', compression='gzip');
 
 REFRESH TABLE {table};


### PR DESCRIPTION
Updates the URL that the `COPY FROM` command uses to be the new version as we can no longer rely on pulling LFS files directly from GitHub.

