### PR TITLE
Wind farms dataset: Add SQL loader snippets

### DIFF
--- a/devrel/uk-offshore-wind-farm-data/wind_farm_output_load.sql
+++ b/devrel/uk-offshore-wind-farm-data/wind_farm_output_load.sql
@@ -1,0 +1,18 @@
+-- CrateDB Example Datasets
+-- https://github.com/crate/cratedb-datasets
+
+CREATE TABLE IF NOT EXISTS {table} (
+    windfarmid TEXT,
+    ts TIMESTAMP WITHOUT TIME ZONE,
+    month GENERATED ALWAYS AS date_trunc('month', ts),
+    day TIMESTAMP WITH TIME ZONE GENERATED ALWAYS AS date_trunc('day', ts),
+    output DOUBLE PRECISION,
+    outputpercentage DOUBLE PRECISION
+) PARTITIONED BY (day);
+
+COPY {table}
+FROM 'https://cdn.crate.io/downloads/datasets/cratedb-datasets/devrel/uk-offshore-wind-farm-data/wind_farm_output.json.gz'
+WITH (compression='gzip')
+RETURN SUMMARY;
+
+REFRESH TABLE {table};

--- a/devrel/uk-offshore-wind-farm-data/wind_farms_load.sql
+++ b/devrel/uk-offshore-wind-farm-data/wind_farms_load.sql
@@ -1,0 +1,26 @@
+-- CrateDB Example Datasets
+-- https://github.com/crate/cratedb-datasets
+
+CREATE TABLE IF NOT EXISTS {table} (
+   id TEXT PRIMARY KEY,
+   name TEXT,
+   description TEXT INDEX USING fulltext WITH (analyzer='english'),
+   description_vec FLOAT_VECTOR(2048),
+   location GEO_POINT,
+   territory TEXT,
+   boundaries GEO_SHAPE INDEX USING geohash WITH (PRECISION='1m', DISTANCE_ERROR_PCT=0.025),
+   turbines OBJECT(STRICT) AS (
+      brand TEXT,
+      model TEXT,
+      locations ARRAY(GEO_POINT),
+      howmany SMALLINT
+   ),
+   capacity DOUBLE PRECISION,
+   url TEXT
+);
+
+COPY {table}
+FROM 'https://cdn.crate.io/downloads/datasets/cratedb-datasets/devrel/uk-offshore-wind-farm-data/wind_farms.json'
+RETURN SUMMARY;
+
+REFRESH TABLE {table};


### PR DESCRIPTION
## About
By providing SQL loader snippets, it becomes easier to load the wind farms dataset programmatically. Information has been sourced from the [repository's README](https://github.com/crate/devrel-offshore-wind-farms-demo/blob/main/README.md#creating-the-database-tables).

## References
- https://github.com/crate/cratedb-toolkit/pull/360

/cc @simonprickett 
