### PR TITLE
Chicago datasets: Add SQL loader snippets

### DIFF
--- a/academy/chicago-data/311_records_load.sql
+++ b/academy/chicago-data/311_records_load.sql
@@ -1,0 +1,45 @@
+-- CrateDB Example Datasets
+-- https://github.com/crate/cratedb-datasets
+
+CREATE TABLE IF NOT EXISTS {table} (
+   srnumber TEXT,
+   srtype TEXT,
+   srshortcode TEXT,
+   createddept TEXT,
+   ownerdept TEXT,
+   status TEXT,
+   origin TEXT,
+   createddate TIMESTAMP,
+   lastmodifieddate TIMESTAMP,
+   closeddate TIMESTAMP,
+   week GENERATED ALWAYS AS date_trunc('week', createddate),
+   isduplicate BOOLEAN,
+   createdhour SMALLINT,
+   createddayofweek SMALLINT,
+   createdmonth SMALLINT,
+   locationdetails OBJECT(DYNAMIC) AS (
+       streetaddress TEXT,
+       city TEXT,
+       state TEXT,
+       zipcode TEXT,
+       streetnumber TEXT,
+       streetdirection TEXT,
+       streetname TEXT,
+       streettype TEXT,
+       communityarea SMALLINT,
+       ward SMALLINT,
+       policesector SMALLINT,
+       policedistrict SMALLINT,
+       policebeat SMALLINT,
+       precinct SMALLINT,
+       latitude DOUBLE PRECISION,
+       longitude DOUBLE PRECISION,
+       location GEO_POINT
+   )
+) PARTITIONED BY (week);
+
+COPY {table}
+FROM 'https://cdn.crate.io/downloads/datasets/cratedb-datasets/academy/chicago-data/311_records_apr_2024.json.gz'
+WITH (compression='gzip') RETURN SUMMARY;
+
+REFRESH TABLE {table};

--- a/academy/chicago-data/beach_weather_station_data_load.sql
+++ b/academy/chicago-data/beach_weather_station_data_load.sql
@@ -1,0 +1,27 @@
+-- CrateDB Example Datasets
+-- https://github.com/crate/cratedb-datasets
+
+CREATE TABLE IF NOT EXISTS {table} (
+    "measurementid" TEXT,
+    "station" TEXT,
+    "ts" TIMESTAMP WITH TIME ZONE,
+    "airtemp" DOUBLE PRECISION,
+    "wetbulbtemp" DOUBLE PRECISION,
+    "humidity" SMALLINT,
+    "rainintensity" DOUBLE PRECISION,
+    "intervalrain" DOUBLE PRECISION,
+    "totalrain" DOUBLE PRECISION,
+    "precipitationtype" SMALLINT,
+    "winddirection" SMALLINT,
+    "windspeed" DOUBLE PRECISION,
+    "maxwindspeed" DOUBLE PRECISION,
+    "pressure" DOUBLE PRECISION,
+    "solarradiation" SMALLINT,
+    "batterylife" DOUBLE PRECISION
+);
+
+COPY {table}
+FROM 'https://cdn.crate.io/downloads/datasets/cratedb-datasets/academy/chicago-data/beach_weather_station_data.csv'
+WITH (format='csv', empty_string_as_null=true) RETURN SUMMARY;
+
+REFRESH TABLE {table};

--- a/academy/chicago-data/beach_weather_stations_load.sql
+++ b/academy/chicago-data/beach_weather_stations_load.sql
@@ -1,0 +1,18 @@
+-- CrateDB Example Datasets
+-- https://github.com/crate/cratedb-datasets
+
+CREATE TABLE IF NOT EXISTS {table} (
+    stationid TEXT,
+    location GEO_POINT,
+    additionalinfo OBJECT(STRICT) AS (
+        altitude SMALLINT,
+        manager TEXT,
+        established SMALLINT
+    )
+);
+
+INSERT INTO {table} (stationid, location, additionalinfo) VALUES
+('Foster', 'POINT(-87.647525 41.976464)', '{{"altitude": 179, "manager": "Chicago Park District", "established": 2003}}'),
+('Oak Street', 'POINT(-87.6228169 41.901997)', '{{"altitude": 185, "manager": "Chicago Park District", "established": 2001}}');
+
+REFRESH TABLE {table};

--- a/academy/chicago-data/chicago_community_areas_with_vectors_load.sql
+++ b/academy/chicago-data/chicago_community_areas_with_vectors_load.sql
@@ -1,0 +1,19 @@
+-- CrateDB Example Datasets
+-- https://github.com/crate/cratedb-datasets
+
+CREATE TABLE IF NOT EXISTS {table} (
+   areanumber INTEGER PRIMARY KEY,
+   name TEXT,
+   details OBJECT(DYNAMIC) AS (
+       description TEXT INDEX USING fulltext WITH (analyzer='english'),
+       description_vec FLOAT_VECTOR(2048),
+       population BIGINT
+   ),
+   boundaries GEO_SHAPE INDEX USING geohash WITH (PRECISION='1m', DISTANCE_ERROR_PCT=0.025)
+);
+
+COPY {table}
+FROM 'https://cdn.crate.io/downloads/datasets/cratedb-datasets/academy/chicago-data/chicago_community_areas_with_vectors.json'
+RETURN SUMMARY;
+
+REFRESH TABLE {table};

--- a/academy/chicago-data/chicago_libraries_load.sql
+++ b/academy/chicago-data/chicago_libraries_load.sql
@@ -1,0 +1,21 @@
+-- CrateDB Example Datasets
+-- https://github.com/crate/cratedb-datasets
+
+CREATE TABLE IF NOT EXISTS {table} (
+   name TEXT,
+   location OBJECT(DYNAMIC) AS (
+       address TEXT,
+       zipcode TEXT,
+       communityarea INTEGER,
+       position GEO_POINT
+   ),
+   hours ARRAY(TEXT),
+   phone TEXT,
+   website TEXT
+);
+
+COPY {table}
+FROM 'https://cdn.crate.io/downloads/datasets/cratedb-datasets/academy/chicago-data/chicago_libraries.json'
+RETURN SUMMARY;
+
+REFRESH TABLE {table};

--- a/academy/chicago-data/taxi_details_load.sql
+++ b/academy/chicago-data/taxi_details_load.sql
@@ -1,0 +1,23 @@
+-- CrateDB Example Datasets
+-- https://github.com/crate/cratedb-datasets
+
+CREATE TABLE IF NOT EXISTS {table} (
+   vehicleid INTEGER,
+   status TEXT,
+   make TEXT,
+   model TEXT,
+   modelyear INTEGER,
+   color TEXT,
+   fuel TEXT,
+   wheelchairaccessible BOOLEAN,
+   operator TEXT,
+   zipcode TEXT,
+   affiliation TEXT,
+   medallion TEXT
+);
+
+COPY {table}
+FROM 'https://cdn.crate.io/downloads/datasets/cratedb-datasets/academy/chicago-data/taxi_details.csv'
+RETURN SUMMARY;
+
+REFRESH TABLE {table};

--- a/academy/chicago-data/taxi_rides_load.sql
+++ b/academy/chicago-data/taxi_rides_load.sql
@@ -1,0 +1,34 @@
+-- CrateDB Example Datasets
+-- https://github.com/crate/cratedb-datasets
+
+CREATE TABLE IF NOT EXISTS {table} (
+   tripid TEXT,
+   vehicleid INTEGER,
+   starttime TIMESTAMP,
+   endtime TIMESTAMP,
+   duration INTEGER,
+   miles DOUBLE PRECISION,
+   pickupcommunityarea SMALLINT,
+   dropoffcommunityarea SMALLINT,
+   fare DOUBLE PRECISION,
+   tips DOUBLE PRECISION,
+   tolls DOUBLE PRECISION,
+   extras DOUBLE PRECISION,
+   totalcost DOUBLE PRECISION,
+   paymenttype TEXT,
+   company TEXT,
+   pickupcentroidlatitude DOUBLE PRECISION,
+   pickupcentroidlongitude DOUBLE PRECISION,
+   pickupcentroidlocation GEO_POINT,
+   dropoffcentroidlatitude DOUBLE PRECISION,
+   dropoffcentroidlongitude DOUBLE PRECISION,
+   dropoffcentroidlocation GEO_POINT
+);
+
+
+COPY {table}
+FROM 'https://cdn.crate.io/downloads/datasets/cratedb-datasets/academy/chicago-data/taxi_rides_apr_2024.json.gz'
+WITH (compression='gzip')
+RETURN SUMMARY;
+
+REFRESH TABLE {table};


### PR DESCRIPTION
## About
By providing SQL loader snippets, it becomes easier to load the chicago datasets programmatically. Information has been sourced from the [academy-fundamentals-course](https://github.com/crate/academy-fundamentals-course) repository.

## References
- https://github.com/crate/cratedb-datasets/pull/26

/cc @simonprickett